### PR TITLE
Select ENTROPY_GENERATOR when BT_LL_NRFXLIB is enabled

### DIFF
--- a/ble_controller/Kconfig
+++ b/ble_controller/Kconfig
@@ -15,6 +15,7 @@ config BT_LL_NRFXLIB
 	bool "Nordic proprietary BLE Link Layer"
 	select ZERO_LATENCY_IRQS
 	select ENTROPY_NRF5_RNG
+    select ENTROPY_GENERATOR
 	help
 	  Use Nordic BLE Link Layer implementation.
 

--- a/ble_controller/Kconfig
+++ b/ble_controller/Kconfig
@@ -15,7 +15,7 @@ config BT_LL_NRFXLIB
 	bool "Nordic proprietary BLE Link Layer"
 	select ZERO_LATENCY_IRQS
 	select ENTROPY_NRF5_RNG
-    select ENTROPY_GENERATOR
+	select ENTROPY_GENERATOR
 	help
 	  Use Nordic BLE Link Layer implementation.
 


### PR DESCRIPTION
Entropy generator used by BT, so it should be selected when
nrfxlib is enabled

Signed-off-by: Vasilyev, Pavel <pavel.vasilyev@nordicsemi.no>